### PR TITLE
Disable docker-build.yml in PRs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,5 +1,7 @@
 name: Publish to Docker Hub
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
 jobs:
   dockerhub:
     runs-on: ubuntu-latest


### PR DESCRIPTION
All Pull Requests currently run the `docker-build.yml` task, which always fails due to the `DOCKER_TOKEN` not being available, making PRs fail one of the checks and being marked with a cross. This should probably not even be attempted in PRs (or alternatively just the docker build should be attempted, not the push to Docker Hub).