### PR TITLE
Avoiding 404 error on root requests

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -433,6 +433,9 @@ func (bot *Bot) socketioServer(port string) {
 
 	router := mux.NewRouter()
 	router.Handle("/socket.io/", server)
+	router.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprintln(w, "Auto-Mute Us is up and running.")
+	})
 
 	log.Printf("Serving at localhost:%s...\n", port)
 	log.Fatal(http.ListenAndServe(":"+port, router))


### PR DESCRIPTION
This PR just adds a simple response to the root url on the internal server.

I'm trying to find a way to keep my heroku instance alive and the best way I found was through https://cron-job.org/. Unfortunately cron-job.org will disable jobs with failing requests and it understandably interprets the 404 response from AutoMuteUs as a failed rejest. This PR creates an endpoint to get non error responses from the server allowing us to hook it to cron-job.org for keeping heroku instances alive. 