### PR TITLE
Docker updating

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+.dockerignore
+.github
+.gitignore
+.goreleaser.yaml
+amongusdiscord.xml
+app.json
+Dockerfile
+LICENSE
+renovate.json
+TODO.org
+
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,26 @@ RUN export TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)") && 
 
 FROM alpine:3.12.1 AS final
 
+# Set up non-root user and app directory
+# * Non-root because of the principle of least privlege
+# * App directory to allow mounting volumes
+RUN addgroup -g 1000 bot && \
+    adduser -HD -u 1000 -G bot bot && \
+    mkdir -p /app/logs /app/config && \
+    chown -R bot:bot /app
+USER bot
+
 # Import the compiled executable from the first stage.
 COPY --from=builder /app /app
 
+# Port used for capture program to report back
 EXPOSE 8123
+# Port used for application command and control
+EXPOSE 5000
+
+ENV CONFIG_PATH="/app/config" \
+    LOG_PATH="/app/logs"
+VOLUME ["/app/config", "/app/logs"]
 
 # Run the compiled binary.
-ENTRYPOINT ["/app"]
+ENTRYPOINT ["/app/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM golang:1.15-alpine AS builder
 
 # Git is required for getting the dependencies.
-RUN apk add git
+# hadolint ignore=DL3018
+RUN apk add --no-cache git
 
 WORKDIR /src
 
@@ -14,14 +15,15 @@ RUN go mod download
 COPY ./ ./
 
 # Build the executable to `/app`. Mark the build as statically linked.
-RUN export TAG=$(git describe --tags $(git rev-list --tags --max-count=1)) && \
+# hadolint ignore=SC2155
+RUN export TAG=$(git describe --tags "$(git rev-list --tags --max-count=1)") && \
     export COMMIT=$(git rev-parse --short HEAD) && \
     CGO_ENABLED=0 \
     go build -installsuffix 'static' \
     -ldflags="-X main.version=${TAG} -X main.commit=${COMMIT}" \
     -o /app .
 
-FROM alpine AS final
+FROM alpine:3.12.1 AS final
 
 # Import the compiled executable from the first stage.
 COPY --from=builder /app /app


### PR DESCRIPTION
# Explanation

As it is now, it's a bit messy to deploy this with docker. I've set it up so, by default, you can cleanly set up volumes to allow taking the container down without losing data, etc.

Plus, I've ran amended the Dockerfile as suggested by hadolint and implemented a non-root user in line with the principle of least privilege.

# Discussion

Is the commit and version information really needed in the binary shipped with docker? As the container itself should already be tagged with this info. If this is not the case a further optimisation can be made by ignoring `.git`.

# Commits

### Lint Docker file with Hadolint

Problems fixed:
```
4 DL3019 Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages
17 SC2046 Quote this to prevent word splitting.
24 DL3006 Always tag the version of an image explicitly
```

Ignored as old apk packages are dropped, which would break future builds
```
4 DL3018 Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
```

Ignored as as it's probably expected behaviour to not fail on non-0 return
```
17 SC2155 Declare and assign separately to avoid masking return values.
```

### Set up non-root user and dedicated app directories

### Add `.dockerignore`

