### PR TITLE
fix(permissions):

### DIFF
--- a/discord/message_handlers.go
+++ b/discord/message_handlers.go
@@ -59,8 +59,8 @@ func (bot *Bot) handleMessageCreate(s *discordgo.Session, m *discordgo.MessageCr
 			isAdmin = true
 			isPermissioned = true
 		} else {
-			isAdmin = sett.HasAdminPerms(m.Author)
-			isPermissioned = sett.HasRolePerms(m.Member)
+			isAdmin = len(sett.AdminUserIDs) == 0 || sett.HasAdminPerms(m.Author)
+			isPermissioned = len(sett.PermissionRoleIDs) == 0 || sett.HasRolePerms(m.Member)
 		}
 
 		if len(contents) == 0 {

--- a/discord/message_handlers.go
+++ b/discord/message_handlers.go
@@ -53,17 +53,13 @@ func (bot *Bot) handleMessageCreate(s *discordgo.Session, m *discordgo.MessageCr
 
 		isAdmin, isPermissioned := false, false
 
-		if len(sett.AdminUserIDs) == 0 || len(sett.PermissionRoleIDs) == 0 {
-			if g.OwnerID == m.Author.ID || len(sett.AdminUserIDs) == 0 {
-				//if no admin roles set, then yes the user has permissions
-				isAdmin = true
-				isPermissioned = true
-			}
-			if len(sett.PermissionRoleIDs) == 0 {
-				isPermissioned = true
-			}
+		if g.OwnerID == m.Author.ID || (len(sett.AdminUserIDs) == 0 && len(sett.PermissionRoleIDs) == 0) {
+			//the guild owner should always have both permissions
+			//or if both permissions are still empty everyone get both
+			isAdmin = true
+			isPermissioned = true
 		} else {
-			isAdmin = g.OwnerID == m.Author.ID || sett.HasAdminPerms(m.Author)
+			isAdmin = sett.HasAdminPerms(m.Author)
 			isPermissioned = sett.HasRolePerms(m.Member)
 		}
 


### PR DESCRIPTION
If AdminUserIDs contains a user id and PermissionRoleIDs is still empty, only the guild owner had admin rights and the user id in AdminUserIDs has no effect.

Fixes #211 