### PR TITLE
docker-compose hotfix: REDIS_ADDR variable switched to ${AUTOMUTEUS_REDIS_ADDR}

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - CAPTURE_TIMEOUT=${CAPTURE_TIMEOUT:-}
 
       # Do **NOT** change this
-      - REDIS_ADDR=${BOT_REDIS_ADDR}
+      - REDIS_ADDR=${AUTOMUTEUS_REDIS_ADDR}
     depends_on:
       - redis
       - galactus


### PR DESCRIPTION
${BOT_REDIS_ADDR} was deprecated, yeah?