### PR TITLE
typo-fix in de/en/fr/nl/zu language (sing./pl. mistake)

### DIFF
--- a/locales/active.de.toml
+++ b/locales/active.de.toml
@@ -8,8 +8,8 @@ other = "was not An Impostor."
 
 ["ascii.AsciiStarfield.remains"]
 hash = "sha1-14858b544c4178af3b770e676768cd4a8136aefa"
-one = "Impostors remains"
-other = "Impostors remains"
+one = "Impostor remains"
+other = "Impostors remain"
 
 ["commands.AllCommands.Ascii.args"]
 hash = "sha1-6aed154ab2628dd6227c03dd2e74735e5c88b65d"

--- a/locales/active.en.toml
+++ b/locales/active.en.toml
@@ -187,5 +187,5 @@
 "state.phase.TASKS" = "TASKS"
 
 ["ascii.AsciiStarfield.remains"]
-one = "Impostor remain"
-other = "Impostors remains"
+one = "Impostor remains"
+other = "Impostors remain"

--- a/locales/active.fr.toml
+++ b/locales/active.fr.toml
@@ -8,8 +8,8 @@ other = "was not An Impostor."
 
 ["ascii.AsciiStarfield.remains"]
 hash = "sha1-14858b544c4178af3b770e676768cd4a8136aefa"
-one = "Impostors remains"
-other = "Impostors remains"
+one = "Impostor remains"
+other = "Impostors remain"
 
 ["commands.AllCommands.Ascii.args"]
 hash = "sha1-6aed154ab2628dd6227c03dd2e74735e5c88b65d"

--- a/locales/active.nl.toml
+++ b/locales/active.nl.toml
@@ -8,8 +8,8 @@ other = "was not An Impostor."
 
 ["ascii.AsciiStarfield.remains"]
 hash = "sha1-14858b544c4178af3b770e676768cd4a8136aefa"
-one = "Impostors remains"
-other = "Impostors remains"
+one = "Impostor remains"
+other = "Impostors remain"
 
 ["commands.AllCommands.Ascii.args"]
 hash = "sha1-6aed154ab2628dd6227c03dd2e74735e5c88b65d"

--- a/locales/active.zu.toml
+++ b/locales/active.zu.toml
@@ -8,8 +8,8 @@ other = "was nyot An Impostow. ØwØ"
 
 ["ascii.AsciiStarfield.remains"]
 hash = "sha1-14858b544c4178af3b770e676768cd4a8136aefa"
-one = "Impostow wemain"
-other = "Impostows wemains ☆w☆"
+one = "Impostow wemains"
+other = "Impostows wemain ☆w☆"
 
 ["commands.AllCommands.Ascii.args"]
 hash = "sha1-6aed154ab2628dd6227c03dd2e74735e5c88b65d"


### PR DESCRIPTION
one typo is all over the place