### PR TITLE
Rectify amonguscapture download link

### DIFF
--- a/discord/message_handlers.go
+++ b/discord/message_handlers.go
@@ -24,7 +24,7 @@ const DefaultMaxActiveGames = 150
 
 var RateLimitGlobalThreshold = 9500
 
-const downloadURL = "https://github.com/denverquane/amonguscapture/releases/latest/download/amonguscapture.exe"
+const downloadURL = "https://github.com/denverquane/amonguscapture/releases/latest/download/amonguscapture.zip"
 
 var urlregex = regexp.MustCompile(`^http(?P<secure>s?)://(?P<host>[\w.-]+)(?::(?P<port>\d+))?/?$`)
 


### PR DESCRIPTION
Since the executable is now in a ZIP folder, the download link is changed to https://github.com/denverquane/amonguscapture/releases/latest/download/amonguscapture.zip