### PR TITLE
sample.env: AUTOMUTEUS_TAG hotfix

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,4 @@
-AUTOMUTEUS_TAG=6
+AUTOMUTEUS_TAG=6.0.0
 GALACTUS_TAG=2.0.0
 
 # change these, but see comment below about HOST/PORT


### PR DESCRIPTION
6.0.0 provided as workaround, goreleaser need to be reconfigured