### PR TITLE
AutoMuteUs exists in the FreeBSD Ports Tree: Add to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,10 @@ unRAID hosting steps are are not yet updated for v3.0+ of AutoMuteUs, and as suc
 
 Heroku hosting steps are are not yet updated for v3.0+ of AutoMuteUs, and as such is not supported at this time.
 
+## FreeBSD
+
+AutoMuteUs exists in the FreeBSD Ports tree as [`games/automuteus`](https://www.freshports.org/games/automuteus/). Instructions are included in the Port.
+
 ## Old version
 If, for whatever reason, you _really_ want to self host, but also don't want to figure out Docker or use Windows and hate Docker because of it (I don't blame you) you can self host [2.4.3](https://github.com/denverquane/automuteus/releases/tag/2.4.3) instead. **If you are using this method, continue using the newest capture!**
 


### PR DESCRIPTION
I maintain a package/"Port" of AutoMuteUs in the FreeBSD Ports tree as [`games/automuteus`](https://www.freshports.org/games/automuteus/). We should mention this in the README.md.