### PR TITLE
fix: improve expiration check for the premium status (v6)

### DIFF
--- a/discord/responses.go
+++ b/discord/responses.go
@@ -630,7 +630,7 @@ func premiumEmbedResponse(guildID string, tier premium.Tier, daysRem int, sett *
 	fields := []*discordgo.MessageEmbedField{}
 
 	if tier != premium.FreeTier {
-		if daysRem > 0 || daysRem == storage.NoExpiryCode {
+		if daysRem > 0 || daysRem == premium.NoExpiryCode {
 			daysRemStr := ""
 			if daysRem > 0 {
 				daysRemStr = sett.LocalizeMessage(&i18n.Message{

--- a/discord/stats.go
+++ b/discord/stats.go
@@ -9,14 +9,13 @@ import (
 	"strings"
 
 	"github.com/automuteus/utils/pkg/game"
-	"github.com/automuteus/utils/pkg/premium"
 	"github.com/automuteus/utils/pkg/rediskey"
 	"github.com/bwmarrin/discordgo"
 	"github.com/denverquane/amongusdiscord/storage"
 	"github.com/nicksnyder/go-i18n/v2/i18n"
 )
 
-func (bot *Bot) UserStatsEmbed(userID, guildID string, sett *storage.GuildSettings, prem premium.Tier) *discordgo.MessageEmbed {
+func (bot *Bot) UserStatsEmbed(userID, guildID string, sett *storage.GuildSettings, isPrem bool) *discordgo.MessageEmbed {
 	gamesPlayed := bot.PostgresInterface.NumGamesPlayedByUserOnServer(userID, guildID)
 	wins := bot.PostgresInterface.NumWinsOnServer(userID, guildID)
 
@@ -65,7 +64,7 @@ func (bot *Bot) UserStatsEmbed(userID, guildID string, sett *storage.GuildSettin
 		"CommandPrefix": sett.CommandPrefix,
 	})
 
-	if prem != premium.FreeTier {
+	if isPrem {
 		leaderBoardSize := sett.GetLeaderboardSize()
 		extraDesc = ""
 		//extraDesc = sett.LocalizeMessage(&i18n.Message{
@@ -537,7 +536,7 @@ func (bot *Bot) MentionWithCacheData(userID, guildID string, sett *storage.Guild
 	return "<@" + userID + ">"
 }
 
-func (bot *Bot) GuildStatsEmbed(guildID string, sett *storage.GuildSettings, prem premium.Tier) *discordgo.MessageEmbed {
+func (bot *Bot) GuildStatsEmbed(guildID string, sett *storage.GuildSettings, isPrem bool) *discordgo.MessageEmbed {
 	gname := ""
 	avatarURL := ""
 	g, err := bot.PrimarySession.Guild(guildID)
@@ -591,7 +590,7 @@ func (bot *Bot) GuildStatsEmbed(guildID string, sett *storage.GuildSettings, pre
 		"CommandPrefix": sett.CommandPrefix,
 	})
 
-	if prem != premium.FreeTier {
+	if isPrem {
 		leaderboardSize := sett.GetLeaderboardSize()
 		leaderboardMin := sett.GetLeaderboardMin()
 		extraDesc = ""
@@ -894,7 +893,7 @@ func (bot *Bot) GuildStatsEmbed(guildID string, sett *storage.GuildSettings, pre
 	return &embed
 }
 
-func (bot *Bot) GameStatsEmbed(guildID, matchID, connectCode string, sett *storage.GuildSettings, prem premium.Tier) *discordgo.MessageEmbed {
+func (bot *Bot) GameStatsEmbed(guildID, matchID, connectCode string, sett *storage.GuildSettings, isPrem bool) *discordgo.MessageEmbed {
 	gameData, err := bot.PostgresInterface.GetGame(guildID, connectCode, matchID)
 	if err != nil {
 		log.Fatal(err)

--- a/storage/postgres.go
+++ b/storage/postgres.go
@@ -184,13 +184,11 @@ func (psqlInterface *PsqlInterface) insertPlayer(player *PostgresUserGame) error
 }
 
 const SecsInADay = 86400
-const SubDays = 31         // use 31 because there shouldn't ever be a gap; whenever a renewal happens on the 31st day, that should be valid
-const NoExpiryCode = -9999 // dumb, but no one would ever have expired premium for 9999 days
 
 func (psqlInterface *PsqlInterface) GetGuildPremiumStatus(guildID string) (premium.Tier, int) {
 	// self-hosting; only return the true guild status if this variable is set
 	if os.Getenv("AUTOMUTEUS_OFFICIAL") == "" {
-		return premium.SelfHostTier, NoExpiryCode
+		return premium.SelfHostTier, premium.NoExpiryCode
 	}
 
 	gid, err := strconv.ParseUint(guildID, 10, 64)
@@ -204,12 +202,12 @@ func (psqlInterface *PsqlInterface) GetGuildPremiumStatus(guildID string) (premi
 		return premium.FreeTier, 0
 	}
 
-	daysRem := NoExpiryCode
+	daysRem := premium.NoExpiryCode
 
 	if guild.TxTimeUnix != nil {
 		diff := time.Now().Unix() - int64(*guild.TxTimeUnix)
 		// 31 - days elapsed
-		daysRem = int(SubDays - (diff / SecsInADay))
+		daysRem = int(premium.SubDays - (diff / SecsInADay))
 	}
 
 	return premium.Tier(guild.Premium), daysRem


### PR DESCRIPTION
**This PR is required for v6 only.**

Since the check was [already implemented in v7](https://github.com/denverquane/automuteus/commit/80ef2096bbd5a7ec541445383e222a3af29fd06b), this PR implement it the similar way as in v7.
Tested in my testbed using faked DB and `AUTOMUTEUS_OFFICIAL`, `MAX_ACTIVE_GAMES` in following situations;
- Free Tier, Premium Tier (Expired), Premium Tier (Active)
- Self-Hosted