### PR TITLE
Use mention format as prefix (for when message content is privileged)

### DIFF
--- a/discord/bot.go
+++ b/discord/bot.go
@@ -114,8 +114,10 @@ func MakeAndStartBot(version, commit, botToken, url, emojiGuildID string, extraT
 	listeningTo := os.Getenv("AUTOMUTEUS_LISTENING")
 	if listeningTo == "" {
 		prefix := os.Getenv("AUTOMUTEUS_GLOBAL_PREFIX")
-		if prefix == "" {
+		if prefix == "" && os.Getenv("AUTOMUTEUS_OFFICIAL") == "" {
 			prefix = ".au"
+		} else if os.Getenv("AUTOMUTEUS_OFFICIAL") != "" {
+			prefix = "@AutoMuteUs"
 		}
 
 		listeningTo = prefix + " help"

--- a/discord/discordGameState.go
+++ b/discord/discordGameState.go
@@ -23,7 +23,7 @@ func (tc TrackingChannel) ToStatusString(sett *storage.GuildSettings) string {
 			Other: "**No Voice Channel! Use `{{.CommandPrefix}} track`!**",
 		},
 			map[string]interface{}{
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			})
 	}
 	return tc.ChannelName
@@ -36,7 +36,7 @@ func (tc TrackingChannel) ToDescString(sett *storage.GuildSettings) string {
 			Other: "**no Voice Channel! Use `{{.CommandPrefix}} track`!**",
 		},
 			map[string]interface{}{
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			})
 	}
 	return sett.LocalizeMessage(&i18n.Message{

--- a/discord/responses.go
+++ b/discord/responses.go
@@ -27,7 +27,7 @@ const ISO8601 = "2006-01-02T15:04:05-0700"
 
 const BasePremiumURL = "https://automute.us/premium?guild="
 
-func helpResponse(isAdmin, isPermissioned bool, commandPrefix string, commands []command.Command, sett *storage.GuildSettings) discordgo.MessageEmbed {
+func helpResponse(isAdmin, isPermissioned bool, commands []command.Command, sett *storage.GuildSettings) discordgo.MessageEmbed {
 	embed := discordgo.MessageEmbed{
 		URL:  "",
 		Type: "",
@@ -40,7 +40,7 @@ func helpResponse(isAdmin, isPermissioned bool, commandPrefix string, commands [
 			Other: "[View the Github Project](https://github.com/denverquane/automuteus) or [Join our Discord](https://discord.gg/ZkqZSWF)\n\nType `{{.CommandPrefix}} help <command>` to see more details on a command!",
 		},
 			map[string]interface{}{
-				"CommandPrefix": commandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			}),
 		Timestamp: "",
 		Color:     15844367, // GOLD

--- a/discord/setting_handlers.go
+++ b/discord/setting_handlers.go
@@ -98,7 +98,7 @@ func getSetting(arg string) setting.SettingType {
 
 func (bot *Bot) HandleSettingsCommand(s *discordgo.Session, m *discordgo.MessageCreate, sett *storage.GuildSettings, args []string, prem bool) {
 	if len(args) == 1 {
-		s.ChannelMessageSendEmbed(m.ChannelID, settingResponse(sett.CommandPrefix, setting.AllSettings, sett, prem))
+		s.ChannelMessageSendEmbed(m.ChannelID, settingResponse(sett.GetCommandPrefix(), setting.AllSettings, sett, prem))
 		return
 	}
 	// if command invalid, no need to reapply changes to json file
@@ -791,7 +791,7 @@ func SettingMatchSummary(s *discordgo.Session, m *discordgo.MessageCreate, sett 
 		},
 			map[string]interface{}{
 				"Minutes":       args[2],
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			}))
 		return false
 	}
@@ -890,7 +890,7 @@ func SettingAutoRefresh(s *discordgo.Session, m *discordgo.MessageCreate, sett *
 		},
 			map[string]interface{}{
 				"Arg":           val,
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			}))
 		return false
 	}
@@ -928,7 +928,7 @@ func SettingMapVersion(s *discordgo.Session, m *discordgo.MessageCreate, sett *s
 		},
 			map[string]interface{}{
 				"Arg":           val,
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			}))
 		return false
 	}
@@ -960,7 +960,7 @@ func SettingLeaderboardNameMention(s *discordgo.Session, m *discordgo.MessageCre
 		},
 			map[string]interface{}{
 				"Arg":           val,
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			}))
 		return false
 	}
@@ -997,7 +997,7 @@ func SettingLeaderboardSize(s *discordgo.Session, m *discordgo.MessageCreate, se
 		},
 			map[string]interface{}{
 				"Number":        args[2],
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			}))
 		return false
 	}
@@ -1037,7 +1037,7 @@ func SettingLeaderboardMin(s *discordgo.Session, m *discordgo.MessageCreate, set
 		},
 			map[string]interface{}{
 				"Number":        args[2],
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			}))
 		return false
 	}
@@ -1129,7 +1129,7 @@ func SettingDisplayRoomCode(s *discordgo.Session, m *discordgo.MessageCreate, se
 		},
 			map[string]interface{}{
 				"Arg":           val,
-				"CommandPrefix": sett.CommandPrefix,
+				"CommandPrefix": sett.GetCommandPrefix(),
 			}))
 		return false
 	}

--- a/discord/stats.go
+++ b/discord/stats.go
@@ -61,7 +61,7 @@ func (bot *Bot) UserStatsEmbed(userID, guildID string, sett *storage.GuildSettin
 		ID:    "responses.userStatsEmbed.NoPremium",
 		Other: "Detailed stats are only available for AutoMuteUs Premium users; type `{{.CommandPrefix}} premium` to learn more",
 	}, map[string]interface{}{
-		"CommandPrefix": sett.CommandPrefix,
+		"CommandPrefix": sett.GetCommandPrefix(),
 	})
 
 	if isPrem {
@@ -587,7 +587,7 @@ func (bot *Bot) GuildStatsEmbed(guildID string, sett *storage.GuildSettings, isP
 		ID:    "responses.guildStatsEmbed.NoPremium",
 		Other: "Detailed stats are only available for AutoMuteUs Premium users; type `{{.CommandPrefix}} premium` to learn more",
 	}, map[string]interface{}{
-		"CommandPrefix": sett.CommandPrefix,
+		"CommandPrefix": sett.GetCommandPrefix(),
 	})
 
 	if isPrem {

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	version = "6.15.1"
+	version = "6.16.0"
 	commit  = "none"
 	date    = "unknown"
 )

--- a/storage/guildSettings.go
+++ b/storage/guildSettings.go
@@ -12,6 +12,8 @@ import (
 const DefaultLeaderboardSize = 3
 const DefaultLeaderboardMin = 3
 
+const OfficialBotMention = "@AutoMuteUs"
+
 type GuildSettings struct {
 	AdminUserIDs             []string        `json:"adminIDs"`
 	PermissionRoleIDs        []string        `json:"permissionRoleIDs"`
@@ -35,7 +37,11 @@ type GuildSettings struct {
 func MakeGuildSettings() *GuildSettings {
 	prefix := os.Getenv("AUTOMUTEUS_GLOBAL_PREFIX")
 	if prefix == "" {
-		prefix = ".au"
+		if os.Getenv("AUTOMUTEUS_OFFICIAL") != "" {
+			prefix = OfficialBotMention
+		} else {
+			prefix = ".au"
+		}
 	}
 	return &GuildSettings{
 		CommandPrefix:            prefix,
@@ -88,6 +94,10 @@ func (gs *GuildSettings) HasRolePerms(mem *discordgo.Member) bool {
 }
 
 func (gs *GuildSettings) GetCommandPrefix() string {
+	// only applies to official bot after 04/31/2022
+	if os.Getenv("AUTOMUTEUS_OFFICIAL") != "" {
+		return OfficialBotMention
+	}
 	return gs.CommandPrefix
 }
 


### PR DESCRIPTION
On May 1st, message content becomes a privileged intent, and the bot will only be able to read message content when mentioned directly. This PR allows the bot to be mentioned using the prefix `@AutoMuteUs`, while preserving the existing custom prefix functionality for self-hosted users